### PR TITLE
Implement Remember Me

### DIFF
--- a/src/auth-enhancements/auth.controller.ts
+++ b/src/auth-enhancements/auth.controller.ts
@@ -1,0 +1,86 @@
+// auth.controller.ts
+import { 
+    Body, 
+    Controller, 
+    Post, 
+    HttpCode, 
+    HttpStatus, 
+    ValidationPipe,
+    Res,
+    Get,
+    Param,
+    BadRequestException 
+  } from '@nestjs/common';
+  import { Response } from 'express';
+  import { AuthService } from './auth.service';
+  import { LoginDto } from './dto/login.dto';
+  import { ForgotPasswordDto } from './dto/forgot-password.dto';
+  import { ResetPasswordDto } from './dto/reset-password.dto';
+  
+  @Controller('auth')
+  export class AuthController {
+    constructor(private readonly authService: AuthService) {}
+  
+    @Post('login')
+    @HttpCode(HttpStatus.OK)
+    async login(
+      @Body() loginDto: LoginDto,
+      @Res({ passthrough: true }) response: Response,
+    ) {
+      const { accessToken, expiresIn, user } = await this.authService.login(
+        loginDto.email,
+        loginDto.password,
+        loginDto.rememberMe || false,
+      );
+  
+      // Set cookie options based on rememberMe flag
+      const cookieOptions = {
+        httpOnly: true,
+        secure: process.env.NODE_ENV !== 'development',
+        maxAge: expiresIn * 1000, // convert to milliseconds
+      };
+  
+      response.cookie('access_token', accessToken, cookieOptions);
+  
+      return {
+        user: {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+        },
+      };
+    }
+  
+    @Post('forgot-password')
+    @HttpCode(HttpStatus.OK)
+    async forgotPassword(@Body() forgotPasswordDto: ForgotPasswordDto) {
+      await this.authService.sendPasswordResetEmail(forgotPasswordDto.email);
+      return { message: 'If your email is registered, you will receive password reset instructions' };
+    }
+  
+    @Post('reset-password')
+    @HttpCode(HttpStatus.OK)
+    async resetPassword(@Body() resetPasswordDto: ResetPasswordDto) {
+      await this.authService.resetPassword(
+        resetPasswordDto.token,
+        resetPasswordDto.password,
+      );
+      return { message: 'Password has been successfully reset' };
+    }
+  
+    @Post('logout')
+    @HttpCode(HttpStatus.OK)
+    async logout(@Res({ passthrough: true }) response: Response) {
+      response.clearCookie('access_token');
+      return { message: 'Logged out successfully' };
+    }
+  
+    @Get('validate-reset-token/:token')
+    async validateResetToken(@Param('token') token: string) {
+      const isValid = await this.authService.validatePasswordResetToken(token);
+      if (!isValid) {
+        throw new BadRequestException('Invalid or expired password reset token');
+      }
+      return { valid: true };
+    }
+  }

--- a/src/auth-enhancements/auth.module.ts
+++ b/src/auth-enhancements/auth.module.ts
@@ -1,0 +1,52 @@
+// auth.module.ts
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PassportModule } from '@nestjs/passport';
+import { MailerModule } from '@nestjs-modules/mailer';
+import { User } from '../users/entities/user.entity';
+import { PasswordReset } from './entities/password-reset.entity';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './strategies/jwt.strategy';
+import { AuthController } from './auth.controller';
+import { UsersModule } from '../users/users.module';
+
+@Module({
+  imports: [
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get('JWT_SECRET'),
+        signOptions: {
+          expiresIn: configService.get('JWT_EXPIRATION', '1h'),
+        },
+      }),
+    }),
+    TypeOrmModule.forFeature([User, PasswordReset]),
+    MailerModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        transport: {
+          host: configService.get('MAIL_HOST'),
+          port: configService.get<number>('MAIL_PORT'),
+          auth: {
+            user: configService.get('MAIL_USER'),
+            pass: configService.get('MAIL_PASSWORD'),
+          },
+        },
+        defaults: {
+          from: configService.get('MAIL_FROM', '"No Reply" <noreply@example.com>'),
+        },
+      }),
+    }),
+    UsersModule,
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+  exports: [AuthService, JwtStrategy, PassportModule],
+})
+export class AuthModule {}

--- a/src/auth-enhancements/auth.service.ts
+++ b/src/auth-enhancements/auth.service.ts
@@ -1,0 +1,148 @@
+// auth.service.ts
+import {
+    Injectable,
+    UnauthorizedException,
+    BadRequestException,
+    NotFoundException,
+    InternalServerErrorException,
+  } from '@nestjs/common';
+  import { JwtService } from '@nestjs/jwt';
+  import { InjectRepository } from '@nestjs/typeorm';
+  import { Repository } from 'typeorm';
+  import { ConfigService } from '@nestjs/config';
+  import { MailerService } from '@nestjs-modules/mailer';
+  import * as bcrypt from 'bcrypt';
+  import { v4 as uuidv4 } from 'uuid';
+  import { User } from '../users/entities/user.entity';
+  import { PasswordReset } from './entities/password-reset.entity';
+  import { JwtPayload } from './interfaces/jwt-payload.interface';
+  
+  @Injectable()
+  export class AuthService {
+    constructor(
+      @InjectRepository(User)
+      private usersRepository: Repository<User>,
+      @InjectRepository(PasswordReset)
+      private passwordResetRepository: Repository<PasswordReset>,
+      private jwtService: JwtService,
+      private configService: ConfigService,
+      private mailerService: MailerService,
+    ) {}
+  
+    async login(email: string, password: string, rememberMe: boolean) {
+      const user = await this.usersRepository.findOne({ where: { email } });
+      if (!user) {
+        throw new UnauthorizedException('Invalid credentials');
+      }
+  
+      const isPasswordValid = await bcrypt.compare(password, user.password);
+      if (!isPasswordValid) {
+        throw new UnauthorizedException('Invalid credentials');
+      }
+  
+      // Set expiration based on rememberMe flag
+      const expiresIn = rememberMe 
+        ? parseInt(this.configService.get('JWT_REMEMBER_EXPIRATION', '2592000')) // 30 days in seconds
+        : parseInt(this.configService.get('JWT_EXPIRATION', '3600')); // 1 hour in seconds
+  
+      const payload: JwtPayload = { sub: user.id, email: user.email };
+      const accessToken = this.jwtService.sign(payload, { expiresIn });
+  
+      return {
+        accessToken,
+        expiresIn,
+        user,
+      };
+    }
+  
+    async sendPasswordResetEmail(email: string) {
+      const user = await this.usersRepository.findOne({ where: { email } });
+  
+      // Always return success even if email doesn't exist (security best practice)
+      if (!user) {
+        return;
+      }
+  
+      // Generate a unique token
+      const token = uuidv4();
+      
+      // Create an expiry date (1 hour from now)
+      const expiresAt = new Date();
+      expiresAt.setHours(expiresAt.getHours() + 1);
+  
+      // Save the reset token in the database
+      await this.passwordResetRepository.save({
+        user,
+        token,
+        expiresAt,
+      });
+  
+      // Generate the reset URL
+      const resetUrl = `${this.configService.get('FRONTEND_URL', 'http://localhost:3000')}/reset-password/${token}`;
+  
+      // Send the email
+      try {
+        await this.mailerService.sendMail({
+          to: user.email,
+          subject: 'Password Reset Request',
+          html: `
+            <h3>Password Reset</h3>
+            <p>You requested a password reset for your account. Click the link below to reset your password:</p>
+            <a href="${resetUrl}">Reset Password</a>
+            <p>This link will expire in 1 hour.</p>
+            <p>If you didn't request this, please ignore this email.</p>
+          `,
+        });
+      } catch (error) {
+        throw new InternalServerErrorException('Failed to send password reset email');
+      }
+    }
+  
+    async validatePasswordResetToken(token: string): Promise<boolean> {
+      const passwordReset = await this.passwordResetRepository.findOne({
+        where: { token },
+        relations: ['user'],
+      });
+  
+      if (!passwordReset || !passwordReset.user) {
+        return false;
+      }
+  
+      // Check if token is expired
+      if (new Date() > passwordReset.expiresAt) {
+        return false;
+      }
+  
+      return true;
+    }
+  
+    async resetPassword(token: string, newPassword: string) {
+      const passwordReset = await this.passwordResetRepository.findOne({
+        where: { token },
+        relations: ['user'],
+      });
+  
+      if (!passwordReset || !passwordReset.user) {
+        throw new BadRequestException('Invalid reset token');
+      }
+  
+      // Check if token is expired
+      if (new Date() > passwordReset.expiresAt) {
+        throw new BadRequestException('Reset token has expired');
+      }
+  
+      // Hash the new password
+      const hashedPassword = await bcrypt.hash(newPassword, 10);
+  
+      // Update user's password
+      await this.usersRepository.update(passwordReset.user.id, {
+        password: hashedPassword,
+      });
+  
+      // Delete the used token
+      await this.passwordResetRepository.delete({ token });
+  
+      // Log password reset event (could be expanded to a proper audit log)
+      console.log(`Password reset for user ID ${passwordReset.user.id} at ${new Date()}`);
+    }
+  }

--- a/src/auth-enhancements/dto/forgot-password.dto.ts
+++ b/src/auth-enhancements/dto/forgot-password.dto.ts
@@ -1,0 +1,8 @@
+// dto/forgot-password.dto.ts
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}

--- a/src/auth-enhancements/dto/login.dto.ts
+++ b/src/auth-enhancements/dto/login.dto.ts
@@ -1,0 +1,16 @@
+// dto/login.dto.ts
+import { IsEmail, IsNotEmpty, IsString, IsOptional, IsBoolean } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @IsString()
+  @IsNotEmpty()
+  password: string;
+
+  @IsBoolean()
+  @IsOptional()
+  rememberMe?: boolean;
+}

--- a/src/auth-enhancements/dto/reset-password.dto.ts
+++ b/src/auth-enhancements/dto/reset-password.dto.ts
@@ -1,0 +1,13 @@
+// dto/reset-password.dto.ts
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(8)
+  password: string;
+}

--- a/src/auth-enhancements/entities/password-reset.entity.ts
+++ b/src/auth-enhancements/entities/password-reset.entity.ts
@@ -1,0 +1,22 @@
+// entities/password-reset.entity.ts
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn, CreateDateColumn } from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity()
+export class PasswordReset {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  token: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column()
+  expiresAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/auth-enhancements/interfaces/jwt-payload.interface.ts
+++ b/src/auth-enhancements/interfaces/jwt-payload.interface.ts
@@ -1,0 +1,7 @@
+// interfaces/jwt-payload.interface.ts
+export interface JwtPayload {
+    sub: string;
+    email: string;
+    iat?: number;
+    exp?: number;
+  }

--- a/src/auth-enhancements/strategies/jwt.strategy.ts
+++ b/src/auth-enhancements/strategies/jwt.strategy.ts
@@ -1,0 +1,39 @@
+// strategies/jwt.strategy.ts
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from '../../users/entities/user.entity';
+import { JwtPayload } from '../interfaces/jwt-payload.interface';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(
+    private configService: ConfigService,
+    @InjectRepository(User)
+    private usersRepository: Repository<User>,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (request) => {
+          return request?.cookies?.access_token;
+        },
+        ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ]),
+      secretOrKey: configService.get('JWT_SECRET'),
+    });
+  }
+
+  async validate(payload: JwtPayload): Promise<User> {
+    const { sub: id } = payload;
+    const user = await this.usersRepository.findOne({ where: { id } });
+
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+
+    return user;
+  }
+}


### PR DESCRIPTION
close #5 

Added support for a `rememberMe` flag in the login endpoint.
- When `rememberMe` is true, a long-lived JWT (e.g. 30 days) is issued.
- Updated cookie/token configuration to support extended client-side storage.
- Ensured appropriate security measures for persistent sessions.

### 📩 Forgot Password
- Created a `POST /auth/forgot-password` endpoint.
- Validates if the submitted email is associated with a registered user.
- Generates a secure, time-limited password reset token (e.g. 1 hour expiry).
- Sends an email containing a tokenized password reset link.

### 🔄 Reset Password
- Created a `POST /auth/reset-password` endpoint.
- Accepts the reset token and a new password.
- Validates token and expiry.
- Hashes and updates the user's password upon successful validation.
- Invalidates the token post-reset and logs the password reset event.