### PR TITLE
feat(settings): Add Entity, Repository, and User Preferences API

### DIFF
--- a/src/settings/dto/create-settings.dto.ts
+++ b/src/settings/dto/create-settings.dto.ts
@@ -1,0 +1,31 @@
+import { IsEnum, IsArray, IsString, IsOptional, IsBoolean, IsInt, Min, Max } from 'class-validator';
+import { NotificationType } from '../entities/settings.entity';
+
+export class CreateSettingsDto {
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  preferredCategories?: string[];
+
+  @IsEnum(NotificationType)
+  @IsOptional()
+  notificationPreferences?: NotificationType;
+
+  @IsBoolean()
+  @IsOptional()
+  soundEnabled?: boolean;
+
+  @IsString()
+  @IsOptional()
+  language?: string;
+
+  @IsInt()
+  @IsOptional()
+  @Min(5)
+  @Max(50)
+  itemsPerPage?: number;
+
+  @IsBoolean()
+  @IsOptional()
+  autoPlayEnabled?: boolean;
+}

--- a/src/settings/dto/update-settings.dto.ts
+++ b/src/settings/dto/update-settings.dto.ts
@@ -1,0 +1,53 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSettingsDto } from './create-settings.dto';
+
+export class UpdateSettingsDto extends PartialType(CreateSettingsDto) {}
+
+// src/settings/settings.repository.ts
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Settings } from './entities/settings.entity';
+import { CreateSettingsDto } from './dto/create-settings.dto';
+import { UpdateSettingsDto } from './dto/update-settings.dto';
+
+@Injectable()
+export class SettingsRepository {
+  constructor(
+    @InjectRepository(Settings)
+    private readonly settingsRepository: Repository<Settings>,
+  ) {}
+
+  async findByUserId(userId: string): Promise<Settings> {
+    return this.settingsRepository.findOne({ where: { userId } });
+  }
+
+  async create(userId: string, createSettingsDto: CreateSettingsDto): Promise<Settings> {
+    const settings = this.settingsRepository.create({
+      userId,
+      ...createSettingsDto,
+    });
+    return this.settingsRepository.save(settings);
+  }
+
+  async update(userId: string, updateSettingsDto: UpdateSettingsDto): Promise<Settings> {
+    const settings = await this.findByUserId(userId);
+    
+    // Update settings if they exist
+    if (settings) {
+      const updatedSettings = { 
+        ...settings,
+        ...updateSettingsDto,
+        updatedAt: new Date()
+      };
+      return this.settingsRepository.save(updatedSettings);
+    }
+    
+    // Create new settings if they don't exist
+    return this.create(userId, updateSettingsDto);
+  }
+
+  async delete(userId: string): Promise<void> {
+    await this.settingsRepository.delete({ userId });
+  }
+}

--- a/src/settings/entities/settings.entity.ts
+++ b/src/settings/entities/settings.entity.ts
@@ -1,0 +1,47 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+export enum NotificationType {
+  NONE = 'none',
+  EMAIL = 'email',
+  PUSH = 'push',
+  ALL = 'all',
+}
+
+@Entity('settings')
+export class Settings {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id' })
+  userId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column('simple-array', { nullable: true })
+  preferredCategories: string[];
+
+  @Column({
+    type: 'enum',
+    enum: NotificationType,
+    default: NotificationType.ALL,
+  })
+  notificationPreferences: NotificationType;
+
+  @Column({ default: true })
+  soundEnabled: boolean;
+
+  @Column({ default: 'en' })
+  language: string;
+
+  @Column({ default: 10 })
+  itemsPerPage: number;
+
+  @Column({ default: true })
+  autoPlayEnabled: boolean;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  updatedAt: Date;
+}

--- a/src/settings/gameplay/gameplay.controller.ts
+++ b/src/settings/gameplay/gameplay.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Post, Body, UseGuards, Req } from '@nestjs/common';
+import { GameplayService } from './gameplay.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+
+@ApiTags('gameplay')
+@Controller('gameplay')
+@UseGuards(JwtAuthGuard)
+export class GameplayController {
+  constructor(private readonly gameplayService: GameplayService) {}
+
+  @Post('start-session')
+  @ApiOperation({ summary: 'Start a new game session applying user preferences' })
+  async startSession(@Req() req, @Body() options: any) {
+    const userId = req.user.id;
+    return this.gameplayService.startGameSession({
+      userId,
+      ...options
+    });
+  }
+}

--- a/src/settings/gameplay/gameplay.module.ts
+++ b/src/settings/gameplay/gameplay.module.ts
@@ -1,0 +1,48 @@
+import { Module } from '@nestjs/common';
+import { GameplayController } from './gameplay.controller';
+import { GameplayService } from './gameplay.service';
+import { SettingsModule } from '../settings/settings.module';
+
+@Module({
+  imports: [SettingsModule],
+  controllers: [GameplayController],
+  providers: [GameplayService],
+  exports: [GameplayService],
+})
+export class GameplayModule {}
+
+// Example usage in notification service
+// src/notifications/notification.service.ts
+import { Injectable } from '@nestjs/common';
+import { GameplayService } from '../gameplay/gameplay.service';
+
+@Injectable()
+export class NotificationService {
+  constructor(private readonly gameplayService: GameplayService) {}
+
+  async sendGameInvitation(userId: string, invitationData: any) {
+    // Check if user wants to receive this type of notification
+    const shouldSendEmail = await this.gameplayService.shouldSendNotification(userId, 'email');
+    const shouldSendPush = await this.gameplayService.shouldSendNotification(userId, 'push');
+    
+    if (shouldSendEmail) {
+      // Send email notification logic
+      console.log(`Sending email notification to user ${userId}`);
+      // emailService.send(...)
+    }
+    
+    if (shouldSendPush) {
+      // Send push notification logic
+      console.log(`Sending push notification to user ${userId}`);
+      // pushService.send(...)
+    }
+    
+    return {
+      notificationSent: shouldSendEmail || shouldSendPush,
+      channels: {
+        email: shouldSendEmail,
+        push: shouldSendPush,
+      }
+    };
+  }
+}

--- a/src/settings/gameplay/gameplay.service.ts
+++ b/src/settings/gameplay/gameplay.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import { SettingsService } from '../settings/settings.service';
+import { NotificationType } from '../settings/entities/settings.entity';
+
+interface GameSessionOptions {
+  userId: string;
+  categories?: string[];
+  difficulty?: string;
+}
+
+@Injectable()
+export class GameplayService {
+  constructor(private readonly settingsService: SettingsService) {}
+
+  async startGameSession(options: GameSessionOptions) {
+    const userId = options.userId;
+    const settings = await this.settingsService.getOrCreateSettings(userId);
+    
+    // Apply user preferences to gameplay
+    const availableCategories = options.categories || ['sports', 'history', 'science', 'entertainment', 'art'];
+    
+    // Filter categories based on user preferences if they have any
+    const filteredCategories = settings.preferredCategories?.length 
+      ? availableCategories.filter(cat => settings.preferredCategories.includes(cat))
+      : availableCategories;
+    
+    // Use user's language preference
+    const language = settings.language || 'en';
+    
+    // Apply auto-play settings
+    const autoPlay = settings.autoPlayEnabled;
+    
+    return {
+      userId,
+      categories: filteredCategories,
+      language,
+      autoPlay,
+      soundEnabled: settings.soundEnabled,
+      itemsPerPage: settings.itemsPerPage,
+      sessionStarted: new Date(),
+    };
+  }
+
+  async shouldSendNotification(userId: string, notificationType: 'email' | 'push'): Promise<boolean> {
+    const settings = await this.settingsService.getOrCreateSettings(userId);
+    
+    switch (settings.notificationPreferences) {
+      case NotificationType.NONE:
+        return false;
+      case NotificationType.EMAIL:
+        return notificationType === 'email';
+      case NotificationType.PUSH:
+        return notificationType === 'push';
+      case NotificationType.ALL:
+      default:
+        return true;
+    }
+  }
+}

--- a/src/settings/settings.controller.ts
+++ b/src/settings/settings.controller.ts
@@ -1,0 +1,73 @@
+import { 
+    Controller, 
+    Get, 
+    Post, 
+    Patch, 
+    Delete, 
+    Body, 
+    Req, 
+    UseGuards, 
+    HttpStatus,
+    HttpCode,
+  } from '@nestjs/common';
+  import { SettingsService } from './settings.service';
+  import { CreateSettingsDto } from './dto/create-settings.dto';
+  import { UpdateSettingsDto } from './dto/update-settings.dto';
+  import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+  import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+  
+  @ApiTags('settings')
+  @Controller('settings')
+  @UseGuards(JwtAuthGuard)
+  export class SettingsController {
+    constructor(private readonly settingsService: SettingsService) {}
+  
+    @Get()
+    @ApiOperation({ summary: 'Get current user settings' })
+    @ApiResponse({ 
+      status: HttpStatus.OK, 
+      description: 'Returns the user settings' 
+    })
+    @ApiResponse({ 
+      status: HttpStatus.NOT_FOUND, 
+      description: 'Settings not found for the user' 
+    })
+    async getSettings(@Req() req) {
+      const userId = req.user.id;
+      return this.settingsService.getOrCreateSettings(userId);
+    }
+  
+    @Post()
+    @ApiOperation({ summary: 'Create settings for the current user' })
+    @ApiResponse({ 
+      status: HttpStatus.CREATED, 
+      description: 'Settings have been created' 
+    })
+    async createSettings(@Req() req, @Body() createSettingsDto: CreateSettingsDto) {
+      const userId = req.user.id;
+      return this.settingsService.createSettings(userId, createSettingsDto);
+    }
+  
+    @Patch()
+    @ApiOperation({ summary: 'Update settings for the current user' })
+    @ApiResponse({ 
+      status: HttpStatus.OK, 
+      description: 'Settings have been updated' 
+    })
+    async updateSettings(@Req() req, @Body() updateSettingsDto: UpdateSettingsDto) {
+      const userId = req.user.id;
+      return this.settingsService.updateSettings(userId, updateSettingsDto);
+    }
+  
+    @Delete()
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Delete settings for the current user' })
+    @ApiResponse({ 
+      status: HttpStatus.NO_CONTENT, 
+      description: 'Settings have been deleted' 
+    })
+    async deleteSettings(@Req() req) {
+      const userId = req.user.id;
+      await this.settingsService.deleteSettings(userId);
+    }
+  }

--- a/src/settings/settings.module.ts
+++ b/src/settings/settings.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SettingsController } from './settings.controller';
+import { SettingsService } from './settings.service';
+import { SettingsRepository } from './settings.repository';
+import { Settings } from './entities/settings.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Settings]),
+  ],
+  controllers: [SettingsController],
+  providers: [SettingsService, SettingsRepository],
+  exports: [SettingsService],
+})
+export class SettingsModule {}

--- a/src/settings/settings.service.ts
+++ b/src/settings/settings.service.ts
@@ -1,0 +1,111 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSettingsDto } from './create-settings.dto';
+
+export class UpdateSettingsDto extends PartialType(CreateSettingsDto) {}
+
+// src/settings/settings.repository.ts
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Settings } from './entities/settings.entity';
+import { CreateSettingsDto } from './dto/create-settings.dto';
+import { UpdateSettingsDto } from './dto/update-settings.dto';
+
+@Injectable()
+export class SettingsRepository {
+  constructor(
+    @InjectRepository(Settings)
+    private readonly settingsRepository: Repository<Settings>,
+  ) {}
+
+  async findByUserId(userId: string): Promise<Settings> {
+    return this.settingsRepository.findOne({ where: { userId } });
+  }
+
+  async create(userId: string, createSettingsDto: CreateSettingsDto): Promise<Settings> {
+    const settings = this.settingsRepository.create({
+      userId,
+      ...createSettingsDto,
+    });
+    return this.settingsRepository.save(settings);
+  }
+
+  async update(userId: string, updateSettingsDto: UpdateSettingsDto): Promise<Settings> {
+    const settings = await this.findByUserId(userId);
+    
+    // Update settings if they exist
+    if (settings) {
+      const updatedSettings = { 
+        ...settings,
+        ...updateSettingsDto,
+        updatedAt: new Date()
+      };
+      return this.settingsRepository.save(updatedSettings);
+    }
+    
+    // Create new settings if they don't exist
+    return this.create(userId, updateSettingsDto);
+  }
+
+  async delete(userId: string): Promise<void> {
+    await this.settingsRepository.delete({ userId });
+  }
+}
+
+// src/settings/settings.service.ts
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { SettingsRepository } from './settings.repository';
+import { Settings } from './entities/settings.entity';
+import { CreateSettingsDto } from './dto/create-settings.dto';
+import { UpdateSettingsDto } from './dto/update-settings.dto';
+
+@Injectable()
+export class SettingsService {
+  constructor(private readonly settingsRepository: SettingsRepository) {}
+
+  async getSettingsByUserId(userId: string): Promise<Settings> {
+    const settings = await this.settingsRepository.findByUserId(userId);
+    if (!settings) {
+      throw new NotFoundException(`Settings for user with ID "${userId}" not found`);
+    }
+    return settings;
+  }
+
+  async createSettings(userId: string, createSettingsDto: CreateSettingsDto): Promise<Settings> {
+    return this.settingsRepository.create(userId, createSettingsDto);
+  }
+
+  async updateSettings(userId: string, updateSettingsDto: UpdateSettingsDto): Promise<Settings> {
+    return this.settingsRepository.update(userId, updateSettingsDto);
+  }
+
+  async getOrCreateSettings(userId: string): Promise<Settings> {
+    let settings = await this.settingsRepository.findByUserId(userId);
+    
+    if (!settings) {
+      // Create default settings if none exist
+      settings = await this.createSettings(userId, {});
+    }
+    
+    return settings;
+  }
+
+  async deleteSettings(userId: string): Promise<void> {
+    return this.settingsRepository.delete(userId);
+  }
+  
+  // Helper method to filter categories based on user preferences
+  async filterCategoriesByUserPreferences(userId: string, allCategories: string[]): Promise<string[]> {
+    const settings = await this.getOrCreateSettings(userId);
+    
+    // If no preferred categories are set or the array is empty, return all categories
+    if (!settings.preferredCategories || settings.preferredCategories.length === 0) {
+      return allCategories;
+    }
+    
+    // Filter categories based on user preferences
+    return allCategories.filter(category => 
+      settings.preferredCategories.includes(category)
+    );
+  }
+}

--- a/src/settings/tests/settings.repository.spec.ts
+++ b/src/settings/tests/settings.repository.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SettingsRepository } from '../settings.repository';
+import { Repository } from 'typeorm';
+import { Settings, NotificationType } from '../entities/settings.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+describe('SettingsRepository', () => {
+  let repository: SettingsRepository;
+  let typeOrmRepository: Repository<Settings>;
+
+  const mockSettings = {
+    id: 'settings-uuid',
+    userId: 'user-uuid',
+    preferredCategories: ['sports', 'science'],
+    notificationPreferences: NotificationType.ALL,
+    soundEnabled: true,
+    language: 'en',
+    itemsPerPage: 10,
+    autoPlayEnabled: true,
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SettingsRepository,
+        {
+          provide: getRepositoryToken(Settings),
+          useValue: {
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    repository = module.get<SettingsRepository>(SettingsRepository);
+    typeOrmRepository = module.get<Repository<Settings>>(getRepositoryToken(Settings));
+  });
+
+  it('should be defined', () => {
+    expect(repository).toBeDefined();
+  });
+
+  describe('findByUserId', () => {
+    it('should find settings by user id', async () => {
+      jest.spyOn(typeOrmRepository, 'findOne').mockResolvedValue(mockSettings as Settings);
+
+      const result = await repository.findByUserId('user-uuid');
+      expect(result).toEqual(mockSettings);
+      expect(typeOrmRepository.findOne).toHaveBeenCalledWith({
+        where: { userId: 'user-uuid' },
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('should create new settings', async () => {
+      const createSettingsDto = {
+        preferredCategories: ['sports', 'science'],
+        notificationPreferences: NotificationType.EMAIL,
+      };
+
+      jest.spyOn(typeOrmRepository, 'create').mockReturnValue({
+        ...mockSettings,
+        ...createSettingsDto,
+      } as Settings);
+
+      jest.spyOn(typeOrmRepository, 'save').mockResolvedValue({
+        ...mockSettings,
+        ...createSettingsDto,
+      } as Settings);
+
+      const result = await repository.create('user-uuid', createSettingsDto);
+      
+      expect(result).toEqual({
+        ...mockSettings,
+        ...createSettingsDto,
+      });
+      
+      expect(typeOrmRepository.create).toHaveBeenCalledWith({
+        userId: 'user-uuid',
+        ...createSettingsDto,
+      });
+      
+      expect(typeOrmRepository.save).toHaveBeenCalled();
+    });
+  });

--- a/src/settings/tests/settings.service.spec.ts
+++ b/src/settings/tests/settings.service.spec.ts
@@ -1,0 +1,191 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SettingsService } from '../settings.service';
+import { SettingsRepository } from '../settings.repository';
+import { NotFoundException } from '@nestjs/common';
+import { NotificationType } from '../entities/settings.entity';
+
+describe('SettingsService', () => {
+  let service: SettingsService;
+  let repository: SettingsRepository;
+
+  const mockSettingsRepository = {
+    findByUserId: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const mockSettings = {
+    id: 'settings-uuid',
+    userId: 'user-uuid',
+    preferredCategories: ['sports', 'science'],
+    notificationPreferences: NotificationType.ALL,
+    soundEnabled: true,
+    language: 'en',
+    itemsPerPage: 10,
+    autoPlayEnabled: true,
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SettingsService,
+        {
+          provide: SettingsRepository,
+          useValue: mockSettingsRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<SettingsService>(SettingsService);
+    repository = module.get<SettingsRepository>(SettingsRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getSettingsByUserId', () => {
+    it('should return settings for a user', async () => {
+      mockSettingsRepository.findByUserId.mockResolvedValue(mockSettings);
+
+      const result = await service.getSettingsByUserId('user-uuid');
+      expect(result).toEqual(mockSettings);
+      expect(mockSettingsRepository.findByUserId).toHaveBeenCalledWith('user-uuid');
+    });
+
+    it('should throw NotFoundException if settings not found', async () => {
+      mockSettingsRepository.findByUserId.mockResolvedValue(null);
+
+      await expect(service.getSettingsByUserId('user-uuid')).rejects.toThrow(
+        new NotFoundException('Settings for user with ID "user-uuid" not found'),
+      );
+    });
+  });
+
+  describe('createSettings', () => {
+    it('should create and return settings', async () => {
+      const createSettingsDto = {
+        preferredCategories: ['sports', 'science'],
+        notificationPreferences: NotificationType.ALL,
+      };
+
+      mockSettingsRepository.create.mockResolvedValue({
+        ...mockSettings,
+        ...createSettingsDto,
+      });
+
+      const result = await service.createSettings('user-uuid', createSettingsDto);
+      
+      expect(result).toEqual({
+        ...mockSettings,
+        ...createSettingsDto,
+      });
+      
+      expect(mockSettingsRepository.create).toHaveBeenCalledWith(
+        'user-uuid',
+        createSettingsDto,
+      );
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('should update and return settings', async () => {
+      const updateSettingsDto = {
+        preferredCategories: ['history', 'art'],
+        soundEnabled: false,
+      };
+
+      const updatedSettings = {
+        ...mockSettings,
+        ...updateSettingsDto,
+      };
+
+      mockSettingsRepository.update.mockResolvedValue(updatedSettings);
+
+      const result = await service.updateSettings('user-uuid', updateSettingsDto);
+      
+      expect(result).toEqual(updatedSettings);
+      expect(mockSettingsRepository.update).toHaveBeenCalledWith(
+        'user-uuid',
+        updateSettingsDto,
+      );
+    });
+  });
+
+  describe('getOrCreateSettings', () => {
+    it('should return existing settings if found', async () => {
+      mockSettingsRepository.findByUserId.mockResolvedValue(mockSettings);
+
+      const result = await service.getOrCreateSettings('user-uuid');
+      
+      expect(result).toEqual(mockSettings);
+      expect(mockSettingsRepository.findByUserId).toHaveBeenCalledWith('user-uuid');
+      expect(mockSettingsRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('should create new settings if not found', async () => {
+      mockSettingsRepository.findByUserId.mockResolvedValue(null);
+      mockSettingsRepository.create.mockResolvedValue(mockSettings);
+
+      const result = await service.getOrCreateSettings('user-uuid');
+      
+      expect(result).toEqual(mockSettings);
+      expect(mockSettingsRepository.findByUserId).toHaveBeenCalledWith('user-uuid');
+      expect(mockSettingsRepository.create).toHaveBeenCalledWith('user-uuid', {});
+    });
+  });
+
+  describe('deleteSettings', () => {
+    it('should delete settings for a user', async () => {
+      mockSettingsRepository.delete.mockResolvedValue(undefined);
+
+      await service.deleteSettings('user-uuid');
+      expect(mockSettingsRepository.delete).toHaveBeenCalledWith('user-uuid');
+    });
+  });
+
+  describe('filterCategoriesByUserPreferences', () => {
+    it('should return all categories if no preferences set', async () => {
+      const settingsWithNoPreferences = {
+        ...mockSettings,
+        preferredCategories: [],
+      };
+      
+      mockSettingsRepository.findByUserId.mockResolvedValue(settingsWithNoPreferences);
+      
+      const allCategories = ['sports', 'history', 'science', 'art', 'entertainment'];
+      const result = await service.filterCategoriesByUserPreferences('user-uuid', allCategories);
+      
+      expect(result).toEqual(allCategories);
+    });
+
+    it('should filter categories based on user preferences', async () => {
+      mockSettingsRepository.findByUserId.mockResolvedValue(mockSettings);
+      
+      const allCategories = ['sports', 'history', 'science', 'art', 'entertainment'];
+      const result = await service.filterCategoriesByUserPreferences('user-uuid', allCategories);
+      
+      expect(result).toEqual(['sports', 'science']);
+    });
+
+    it('should create default settings and return all categories if no settings found', async () => {
+      mockSettingsRepository.findByUserId.mockResolvedValue(null);
+      mockSettingsRepository.create.mockResolvedValue({
+        ...mockSettings,
+        preferredCategories: [],
+      });
+      
+      const allCategories = ['sports', 'history', 'science', 'art', 'entertainment'];
+      const result = await service.filterCategoriesByUserPreferences('user-uuid', allCategories);
+      
+      expect(result).toEqual(allCategories);
+      expect(mockSettingsRepository.create).toHaveBeenCalledWith('user-uuid', {});
+    });
+  });
+});


### PR DESCRIPTION
Description:
This PR introduces the ability for users to customize their gameplay experience and notification preferences. Key features include:

    Creation of a Settings entity with fields: id, userId, preferred Categories, and notification Preferences

    Implementation of a TypeORM repository for Settings

    New API endpoints to update and retrieve user settings

    Enforcement of user-defined preferences during gameplay (e.g. filtering questions by preferred categories)

    Unit tests for the SettingsService to ensure reliability and correctness

Checklist:

Define and implement Settings entity

Create TypeORM repository for settings

Build endpoints for settings CRUD operations

Enforce preferred categories during gameplay

    Write tests for settings logic

