### PR TITLE
feat: implement admin routes and role-based access control

### DIFF
--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Role } from '../auth/roles/role.enum';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+  let service: AdminService;
+
+  const mockAdminService = {
+    findAllUsers: jest
+      .fn()
+      .mockResolvedValue([{ id: '1', email: 'user@test.com' }]),
+    deleteUser: jest.fn().mockResolvedValue({ message: 'User deleted' }),
+  };
+
+  // Mock user payloads for testing
+  const adminUser = { userId: 'admin-id', roles: [Role.Admin] };
+  const regularUser = { userId: 'user-id', roles: [Role.User] };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [
+        {
+          provide: AdminService,
+          useValue: mockAdminService,
+        },
+      ],
+    })
+
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (context) => {
+          const req = context.switchToHttp().getRequest();
+          req.user = req.headers.userrole === 'admin' ? adminUser : regularUser;
+          return true;
+        },
+      })
+      .overrideGuard(RolesGuard)
+      .useValue({
+        canActivate: (context) => {
+          const req = context.switchToHttp().getRequest();
+          return req.user.roles.includes(Role.Admin);
+        },
+      })
+      .compile();
+
+    controller = module.get<AdminController>(AdminController);
+    service = module.get<AdminService>(AdminService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('GET /admin/users', () => {
+    it('should allow an admin to find all users', async () => {
+      const result = await controller.findAllUsers();
+      expect(result).toBeDefined();
+      expect(mockAdminService.findAllUsers).toHaveBeenCalled();
+    });
+  });
+
+  describe('DELETE /admin/users/:id', () => {
+    it('should allow an admin to delete a user', async () => {
+      const userId = 'some-uuid';
+      await controller.deleteUser(userId);
+      expect(mockAdminService.deleteUser).toHaveBeenCalledWith(userId);
+    });
+  });
+});

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  Delete,
+  Param,
+  UseGuards,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/roles/roles.decorator';
+import { Role } from '../auth/roles/role.enum';
+import { AdminService } from './admin.service';
+
+@Controller('admin')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Admin)
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  // --- User Management ---
+  @Get('users')
+  findAllUsers() {
+    return this.adminService.findAllUsers();
+  }
+
+  @Delete('users/:id')
+  deleteUser(@Param('id', ParseUUIDPipe) id: string) {
+    return this.adminService.deleteUser(id);
+  }
+
+  // --- Lyrics Management ---
+  @Get('lyrics')
+  findAllLyrics() {
+    return this.adminService.findAllLyrics();
+  }
+
+  @Delete('lyrics/:id')
+  deleteLyric(@Param('id', ParseUUIDPipe) id: string) {
+    return this.adminService.deleteLyric(id);
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { AdminController } from './admin.controller';
+import { UsersModule } from '../users/users.module';
+import { LyricsModule } from '../lyrics/lyrics.module';
+
+@Module({
+  imports: [UsersModule, LyricsModule],
+  controllers: [AdminController],
+  providers: [AdminService],
+})
+export class AdminModule {}

--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminService } from './admin.service';
+
+describe('AdminService', () => {
+  let service: AdminService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AdminService],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { UsersService } from '../users/users.service';
+import { LyricsService } from 'src/lyrics/lyrics.service';
+
+@Injectable()
+export class AdminService {
+  constructor(
+    private usersService: UsersService,
+    private lyricsService: LyricsService,
+  ) {}
+
+  findAllUsers() {
+    return this.usersService.findAll();
+  }
+
+  async deleteUser(id: string) {
+    const result = await this.usersService.remove(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`User with ID "${id}" not found`);
+    }
+    return { message: `User with ID ${id} deleted successfully.` };
+  }
+
+  findAllLyrics() {
+    return this.lyricsService.findAll();
+  }
+
+  deleteLyric(id: string) {
+    return this.lyricsService.remove(id);
+  }
+}

--- a/src/admin/dto/create-admin.dto.ts
+++ b/src/admin/dto/create-admin.dto.ts
@@ -1,0 +1,1 @@
+export class CreateAdminDto {}

--- a/src/admin/dto/update-admin.dto.ts
+++ b/src/admin/dto/update-admin.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAdminDto } from './create-admin.dto';
+
+export class UpdateAdminDto extends PartialType(CreateAdminDto) {}

--- a/src/admin/entities/admin.entity.ts
+++ b/src/admin/entities/admin.entity.ts
@@ -1,0 +1,1 @@
+export class Admin {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { GameSessionsModule } from './game-sessions/game-sessions.module';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 import { RolesGuard } from './auth/guards/roles.guard';
 import { cacheConfig } from './config/cache.config';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
@@ -81,12 +82,12 @@ import { cacheConfig } from './config/cache.config';
           },
 
           entities: [__dirname + '/**/*.entity{.ts,.js}'],
-          synchronize: false, 
+          synchronize: false,
 
           // --- Query Performance Logging ---
           // Log all queries and errors
-          logging: ['query', 'error'], 
-           // Log queries that take longer than 250ms
+          logging: ['query', 'error'],
+          // Log queries that take longer than 250ms
           maxQueryExecutionTime: 250,
 
           // --- Connection Pooling Configuration ---
@@ -99,7 +100,8 @@ import { cacheConfig } from './config/cache.config';
     UsersModule,
     AuthModule,
     GameSessionsModule,
-  LyricsModule,
+    LyricsModule,
+    AdminModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -94,7 +94,10 @@ export class AuthService {
     // Verify password using helper
     let isPasswordValid: boolean;
     try {
-      isPasswordValid = await this.validatePassword(password, user.passwordHash);
+      isPasswordValid = await this.validatePassword(
+        password,
+        user.passwordHash,
+      );
     } catch (err) {
       throw new UnauthorizedException('Invalid credentials');
     }
@@ -112,6 +115,7 @@ export class AuthService {
       sub: user.id,
       email: user.email,
       username: user.username,
+      roles: [user.role],
     };
     const accessToken = this.jwtService.sign(payload);
 
@@ -119,7 +123,7 @@ export class AuthService {
     const { passwordHash: _, ...userWithoutPassword } = user;
 
     return {
-      accessToken,
+      accessToken: this.jwtService.sign(payload),
       user: userWithoutPassword,
     };
   }
@@ -135,8 +139,11 @@ export class AuthService {
   }
 
   // Validate a plaintext password against a hash
-  
-  private async validatePassword(plain: string, hashed: string): Promise<boolean> {
+
+  private async validatePassword(
+    plain: string,
+    hashed: string,
+  ): Promise<boolean> {
     try {
       return await bcrypt.compare(plain, hashed);
     } catch (err) {

--- a/src/auth/guards/roles.guard.spec.ts
+++ b/src/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,47 @@
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import { Role } from '../roles/role.enum';
+import { ExecutionContext } from '@nestjs/common';
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RolesGuard(reflector);
+  });
+
+  const createMockExecutionContext = (user: any): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+      }),
+      getHandler: () => {},
+      getClass: () => {},
+    }) as any;
+
+  it('should allow access if no roles are required', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
+    const mockContext = createMockExecutionContext({ roles: [Role.User] });
+    expect(guard.canActivate(mockContext)).toBe(true);
+  });
+
+  it('should deny access if user has no roles assigned', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([Role.Admin]);
+    const mockContext = createMockExecutionContext({ roles: [] });
+    expect(guard.canActivate(mockContext)).toBe(false);
+  });
+
+  it('should deny access if user does not have the required role', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([Role.Admin]);
+    const mockContext = createMockExecutionContext({ roles: [Role.User] });
+    expect(guard.canActivate(mockContext)).toBe(false);
+  });
+
+  it('should allow access if user has the required admin role', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([Role.Admin]);
+    const mockContext = createMockExecutionContext({ roles: [Role.Admin] });
+    expect(guard.canActivate(mockContext)).toBe(true);
+  });
+});

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,12 +1,18 @@
-import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-
+import { Role } from '../roles/role.enum';
+import { ROLES_KEY } from '../roles/roles.decorator';
 @Injectable()
 export class RolesGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const requiredRoles = this.reflector.getAllAndOverride<string[]>('roles', [
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
       context.getHandler(),
       context.getClass(),
     ]);
@@ -14,9 +20,7 @@ export class RolesGuard implements CanActivate {
       return true;
     }
     const { user } = context.switchToHttp().getRequest();
-    if (!user || !requiredRoles.includes(user.role)) {
-      throw new ForbiddenException('You do not have permission (roles)');
-    }
-    return true;
+    // The user object now contains the roles from the JWT payload
+    return requiredRoles.some((role) => user.roles?.includes(role));
   }
 }

--- a/src/auth/interfaces/jwt-payload.interface.ts
+++ b/src/auth/interfaces/jwt-payload.interface.ts
@@ -1,7 +1,10 @@
+import { Role } from '../roles/role.enum';
+
 export interface JwtPayload {
   sub: string; // user ID
   email: string;
   username: string;
   iat?: number;
   exp?: number;
+  roles?: Role[] | undefined;
 }

--- a/src/auth/roles/role.enum.ts
+++ b/src/auth/roles/role.enum.ts
@@ -1,0 +1,4 @@
+export enum Role {
+  User = 'user',
+  Admin = 'admin',
+}

--- a/src/auth/roles/roles.decorator.ts
+++ b/src/auth/roles/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from './role.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/game-logic/game-logic.service.ts
+++ b/src/game-logic/game-logic.service.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { UserLevel } from '../users/entities/user.entity'
-import { XpLevelService } from '../xp-level/xp-level.service'
+import { UserLevel } from '../users/entities/user.entity';
+import { XpLevelService } from '../xp-level/xp-level.service';
 
 @Injectable()
 export class GameLogicService {
   constructor(
-    @InjectRepository(UserLevel) private readonly userRepo: Repository<UserLevel>,
+    @InjectRepository(UserLevel)
+    private readonly userRepo: Repository<UserLevel>,
     private readonly xpLevelService: XpLevelService,
   ) {}
 

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -9,6 +9,7 @@ import {
   OneToMany,
 } from 'typeorm';
 import { GameSession } from '../../game-sessions/entities/game-session.entity';
+import { Role } from 'src/auth/roles/role.enum';
 
 export enum UserLevel {
   GOSSIP_ROOKIE = 'Gossip Rookie',
@@ -59,9 +60,14 @@ export class User {
   @Column({ nullable: true })
   lastLoginAt?: Date;
 
-  @Column({ type: 'varchar', length: 20, default: 'user' })
-  role: string; // 'user' or 'admin'
+  @Column({
+    type: 'varchar',
+    length: 20,
+    enum: Role,
+    default: Role.User,
+  }) // Default role for new users
+  role: Role; // 'user' or 'admin'
 
-  @OneToMany(() => GameSession, gameSession => gameSession.player)
+  @OneToMany(() => GameSession, (gameSession) => gameSession.player)
   gameSessions: GameSession[];
 }


### PR DESCRIPTION
This PR introduces a secure admin panel by implementing role-based access control (RBAC). It adds an `AdminModule` with protected routes for managing users and lyrics.

**Key Changes**
- A role field has been added to the `User` entity.
- A `RolesGuard` and `@Roles()` decorator now protect routes, ensuring they are only accessible to users with the `admin` role.
- The JWT payload now includes the user's role for stateless authorization. 
- Added tests

Closes #57 